### PR TITLE
Added vars for `position: sticky` + updated README

### DIFF
--- a/modules/iotacss-utils-position/README.md
+++ b/modules/iotacss-utils-position/README.md
@@ -18,6 +18,7 @@ $iota-utils-position-absolute-name        : 'absolute' !default;
 $iota-utils-position-fixed-name           : 'fixed' !default;
 $iota-utils-position-relative-name        : 'relative' !default;
 $iota-utils-position-static-name          : 'static' !default;
+$iota-utils-position-sticky-name          : 'sticky' !default;
 
 $iota-utils-position-res                  : false !default;
 $iota-utils-position-breakpoints          : $iota-global-breakpoints !default;
@@ -31,6 +32,7 @@ $iota-utils-position-breakpoints          : $iota-global-breakpoints !default;
 .u-fixed
 .u-relative
 .u-static
+.u-sticky
 
 
 // Responsive Class Syntax

--- a/modules/iotacss-utils-position/_utilities.position.scss
+++ b/modules/iotacss-utils-position/_utilities.position.scss
@@ -12,6 +12,7 @@ $iota-utils-position-absolute-name        : 'absolute' !default;
 $iota-utils-position-fixed-name           : 'fixed' !default;
 $iota-utils-position-relative-name        : 'relative' !default;
 $iota-utils-position-static-name          : 'static' !default;
+$iota-utils-position-sticky-name          : 'sticky' !default;
 
 $iota-utils-position-res                  : false !default;
 $iota-utils-position-breakpoints          : $iota-global-breakpoints !default;
@@ -44,6 +45,10 @@ $iota-utils-position-var-position: $iota-global-utilities-namespace + $iota-util
   position: static !important;
 }
 
+.#{$iota-utils-position-var-position + $iota-utils-position-sticky-name} {
+  position: sticky !important;
+}
+
 
 
 
@@ -69,6 +74,10 @@ $iota-utils-position-var-position: $iota-global-utilities-namespace + $iota-util
 
       .#{$iota-utils-position-var-position + $iota-utils-position-static-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         position: static !important;
+      }
+      
+      .#{$iota-utils-position-var-position + $iota-utils-position-sticky-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        position: sticky !important;
       }
 
     }


### PR DESCRIPTION
The default values didn't allow for elements with `position: sticky`: https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning

This PR addresses that. Will also submit a PR to iotaplate that creates the default var.