### PR TITLE
Justify Content

### DIFF
--- a/modules/iotacss-utils-justifycontent/LICENSE
+++ b/modules/iotacss-utils-justifycontent/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017 Dimitris Psaropoulos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/modules/iotacss-utils-justifycontent/README.md
+++ b/modules/iotacss-utils-justifycontent/README.md
@@ -1,0 +1,41 @@
+# Justify Content Utility #
+
+The justify content utility contains helper classes for the CSS justify-content property.
+
+
+### Installation ###
+
+```
+npm install --save iotacss-utils-justifycontent
+```
+
+
+### Options ###
+
+```sass
+$iota-utils-justifycontent-namespace            : '' !default;
+$iota-utils-justifycontent-flexstart-name       : 'flexstart' !default;
+$iota-utils-justifycontent-flexend-name         : 'flexend' !default;
+$iota-utils-justifycontent-center-name          : 'center' !default;
+$iota-utils-justifycontent-spacebetween-name    : 'spacebetween' !default;
+$iota-utils-justifycontent-spacearound-name     : 'spacearound' !default;
+
+$iota-utils-justifycontent-res                  : false !default;
+$iota-utils-justifycontent-breakpoints          : $iota-global-breakpoints !default;
+```
+
+
+### Classes ###
+
+```css
+.u-jc-flexstart
+.u-jc-flexend
+.u-jc-center
+.u-jc-spacebetween
+.u-jc-spacearound
+
+
+// Responsive Class Syntax
+
+.u-jc-[name]@[breakpoint-name]  // Example: u-jc-flexstart@sm
+```

--- a/modules/iotacss-utils-justifycontent/README.md
+++ b/modules/iotacss-utils-justifycontent/README.md
@@ -13,29 +13,29 @@ npm install --save iotacss-utils-justifycontent
 ### Options ###
 
 ```sass
-$iota-utils-justifycontent-namespace            : '' !default;
-$iota-utils-justifycontent-flexstart-name       : 'flexstart' !default;
-$iota-utils-justifycontent-flexend-name         : 'flexend' !default;
-$iota-utils-justifycontent-center-name          : 'center' !default;
-$iota-utils-justifycontent-spacebetween-name    : 'spacebetween' !default;
-$iota-utils-justifycontent-spacearound-name     : 'spacearound' !default;
+$iota-utils-jc-namespace            : 'jc' !default;
+$iota-utils-jc-start-name       	: 'start' !default;
+$iota-utils-jc-end-name         	: 'end' !default;
+$iota-utils-jc-center-name          : 'center' !default;
+$iota-utils-jc-between-name    		: 'between' !default;
+$iota-utils-jc-around-name     		: 'around' !default;
 
-$iota-utils-justifycontent-res                  : false !default;
-$iota-utils-justifycontent-breakpoints          : $iota-global-breakpoints !default;
+$iota-utils-jc-res                  : false !default;
+$iota-utils-jc-breakpoints          : $iota-global-breakpoints !default;
 ```
 
 
 ### Classes ###
 
 ```css
-.u-jc-flexstart
-.u-jc-flexend
+.u-jc-start
+.u-jc-end
 .u-jc-center
-.u-jc-spacebetween
-.u-jc-spacearound
+.u-jc-between
+.u-jc-around
 
 
 // Responsive Class Syntax
 
-.u-jc-[name]@[breakpoint-name]  // Example: u-jc-flexstart@sm
+.u-jc-[name]@[breakpoint-name]  // Example: u-jc-start@sm
 ```

--- a/modules/iotacss-utils-justifycontent/_utilities.justifycontent.scss
+++ b/modules/iotacss-utils-justifycontent/_utilities.justifycontent.scss
@@ -1,0 +1,86 @@
+//  Justify Content Utility
+
+
+
+// Options
+
+$iota-utils-justifycontent                      : true;
+
+$iota-utils-justifycontent-namespace            : 'jc' !default;
+$iota-utils-justifycontent-flexstart-name       : 'flexstart' !default;
+$iota-utils-justifycontent-flexend-name         : 'flexend' !default;
+$iota-utils-justifycontent-center-name          : 'center' !default;
+$iota-utils-justifycontent-spacebetween-name    : 'spacebetween' !default;
+$iota-utils-justifycontent-spacearound-name     : 'spacearound' !default;
+
+$iota-utils-justifycontent-res                  : false !default;
+$iota-utils-justifycontent-breakpoints          : $iota-global-breakpoints !default;
+
+
+
+
+// Helper Local Variables
+
+$iota-utils-justifycontent-var-justifycontent: $iota-global-utilities-namespace + $iota-utils-justifycontent-namespace;
+
+
+
+
+// Justify Content Utilities
+
+.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexstart-name} {
+  justify-content: flex-start !important;
+}
+
+.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexend-name} {
+  justify-content: flex-end !important;
+}
+
+.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-center-name} {
+  justify-content: center !important;
+}
+
+.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacebetween-name} {
+  justify-content: space-between !important;
+}
+
+.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacearound-name} {
+  justify-content: space-around !important;
+}
+
+
+
+
+// Justify Content Responsive Utilities
+
+@if $iota-utils-justifycontent-res {
+
+  @each $breakpoint-name, $breakpoint-size in $iota-utils-justifycontent-breakpoints {
+
+    @media #{$breakpoint-size} {
+
+      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexstart-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        justify-content: flex-start !important;
+      }
+
+      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexend-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        justify-content: flex-end !important;
+      }
+
+      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-center-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        justify-content: center !important;
+      }
+
+      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacebetween-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        justify-content: space-between !important;
+      }
+      
+      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacearound-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+        justify-content: space-around !important;
+      }
+
+    }
+
+  }
+
+}

--- a/modules/iotacss-utils-justifycontent/_utilities.justifycontent.scss
+++ b/modules/iotacss-utils-justifycontent/_utilities.justifycontent.scss
@@ -4,47 +4,47 @@
 
 // Options
 
-$iota-utils-justifycontent                      : true;
+$iota-utils-jc                      : true;
 
-$iota-utils-justifycontent-namespace            : 'jc' !default;
-$iota-utils-justifycontent-flexstart-name       : 'flexstart' !default;
-$iota-utils-justifycontent-flexend-name         : 'flexend' !default;
-$iota-utils-justifycontent-center-name          : 'center' !default;
-$iota-utils-justifycontent-spacebetween-name    : 'spacebetween' !default;
-$iota-utils-justifycontent-spacearound-name     : 'spacearound' !default;
+$iota-utils-jc-namespace            : 'jc' !default;
+$iota-utils-jc-start-name           : 'start' !default;
+$iota-utils-jc-end-name             : 'end' !default;
+$iota-utils-jc-center-name          : 'center' !default;
+$iota-utils-jc-between-name         : 'between' !default;
+$iota-utils-jc-around-name          : 'around' !default;
 
-$iota-utils-justifycontent-res                  : false !default;
-$iota-utils-justifycontent-breakpoints          : $iota-global-breakpoints !default;
+$iota-utils-jc-res                  : false !default;
+$iota-utils-jc-breakpoints          : $iota-global-breakpoints !default;
 
 
 
 
 // Helper Local Variables
 
-$iota-utils-justifycontent-var-justifycontent: $iota-global-utilities-namespace + $iota-utils-justifycontent-namespace;
+$iota-utils-jc-var-jc: $iota-global-utilities-namespace + $iota-utils-jc-namespace;
 
 
 
 
 // Justify Content Utilities
 
-.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexstart-name} {
+.#{$iota-utils-jc-var-jc + $iota-utils-jc-start-name} {
   justify-content: flex-start !important;
 }
 
-.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexend-name} {
+.#{$iota-utils-jc-var-jc + $iota-utils-jc-end-name} {
   justify-content: flex-end !important;
 }
 
-.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-center-name} {
+.#{$iota-utils-jc-var-jc + $iota-utils-jc-center-name} {
   justify-content: center !important;
 }
 
-.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacebetween-name} {
+.#{$iota-utils-jc-var-jc + $iota-utils-jc-between-name} {
   justify-content: space-between !important;
 }
 
-.#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacearound-name} {
+.#{$iota-utils-jc-var-jc + $iota-utils-jc-around-name} {
   justify-content: space-around !important;
 }
 
@@ -53,29 +53,29 @@ $iota-utils-justifycontent-var-justifycontent: $iota-global-utilities-namespace 
 
 // Justify Content Responsive Utilities
 
-@if $iota-utils-justifycontent-res {
+@if $iota-utils-jc-res {
 
-  @each $breakpoint-name, $breakpoint-size in $iota-utils-justifycontent-breakpoints {
+  @each $breakpoint-name, $breakpoint-size in $iota-utils-jc-breakpoints {
 
     @media #{$breakpoint-size} {
 
-      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexstart-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+      .#{$iota-utils-jc-var-jc + $iota-utils-jc-start-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         justify-content: flex-start !important;
       }
 
-      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-flexend-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+      .#{$iota-utils-jc-var-jc + $iota-utils-jc-end-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         justify-content: flex-end !important;
       }
 
-      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-center-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+      .#{$iota-utils-jc-var-jc + $iota-utils-jc-center-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         justify-content: center !important;
       }
 
-      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacebetween-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+      .#{$iota-utils-jc-var-jc + $iota-utils-jc-between-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         justify-content: space-between !important;
       }
       
-      .#{$iota-utils-justifycontent-var-justifycontent + $iota-utils-justifycontent-spacearound-name + $iota-global-breakpoint-separator + $breakpoint-name} {
+      .#{$iota-utils-jc-var-jc + $iota-utils-jc-around-name + $iota-global-breakpoint-separator + $breakpoint-name} {
         justify-content: space-around !important;
       }
 

--- a/modules/iotacss-utils-justifycontent/package.json
+++ b/modules/iotacss-utils-justifycontent/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "iotacss-utils-justifycontent",
+  "version": "1.0.1",
+  "description": "Justify Content utility for iotaCSS",
+  "main": "_utilities.justifycontent.scss",
+  "repository": "https://github.com/iotacss/iotacss/tree/master/modules/iotacss-utils-justifycontent",
+  "license": "Apache-2.0",
+  "keywords": [
+    "iotacss",
+    "css",
+    "sass",
+    "bem",
+    "oocss"
+  ],
+  "author": "Dimitris Psaropoulos <info@harby.me>"
+}

--- a/utilities/_justifycontent.scss
+++ b/utilities/_justifycontent.scss
@@ -1,0 +1,1 @@
+@import '../modules/iotacss-utils-position/utilities.justifycontent';

--- a/utilities/_justifycontent.scss
+++ b/utilities/_justifycontent.scss
@@ -1,1 +1,1 @@
-@import '../modules/iotacss-utils-position/utilities.justifycontent';
+@import '../modules/iotacss-utils-justifycontent/utilities.justifycontent';


### PR DESCRIPTION
A utility for Justify-content.

Default namespaces definitely debatable based on previous patterns that Iota has in place.

Only point to make is that there _should_ be a default namespace for this set of utilities, as the values (`center`, `flex-start`...) are possible values for other properties (`align-items`).

I've used `jc` here as we have quite a lengthy set of names anyway, like `justify-content-space-around`.