### PR TITLE
Adding box shadow module

### DIFF
--- a/modules/iotacss-utils-shadow/LICENSE
+++ b/modules/iotacss-utils-shadow/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017 Dimitris Psaropoulos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/modules/iotacss-utils-shadow/README.md
+++ b/modules/iotacss-utils-shadow/README.md
@@ -1,0 +1,38 @@
+# Box Shadow Utility
+
+The box shadow utility contains helper classes for the box-shadow CSS property.
+
+### Installation
+
+```
+npm install --save iotacss-utils-shadow
+```
+
+### Options
+
+```sass
+$iota-utils-shadow-namespace : 'shadow-' !default;
+
+$iota-utils-shadow-names     : () !default;
+```
+
+### Example
+
+```sass
+$iota-shadow-names: (
+    1: 0px 2px 10px rgba(0, 0, 0, 0.1),
+    2: 0px 4px 20px rgba(0, 0, 0, 0.2)
+);
+```
+
+It will generate:
+
+```css
+.u-shadow-1 {
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1) !important;
+}
+
+.u-shadow-2 {
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.2) !important;
+}
+```

--- a/modules/iotacss-utils-shadow/_utilities.shadow.scss
+++ b/modules/iotacss-utils-shadow/_utilities.shadow.scss
@@ -1,0 +1,25 @@
+// Box Shadow Utility
+
+// Options
+
+$iota-utils-shadow: true;
+
+$iota-utils-shadow-namespace: 'shadow-' !default;
+
+$iota-utils-shadow-names: (
+    1: 0px 2px 10px rgba(0, 0, 0, 0.1),
+    2: 0px 4px 20px rgba(0, 0, 0, 0.15)
+) !default;
+
+// Helper Local Variables
+
+$iota-utils-shadow-var: $iota-global-utilities-namespace +
+    $iota-utils-shadow-namespace;
+
+// Box Shadow Utilities
+
+@each $shadow-name, $shadow-value in $iota-utils-shadow-names {
+    .#{$iota-utils-shadow-var + $shadow-name} {
+        box-shadow: #{$shadow-value} !important;
+    }
+}

--- a/modules/iotacss-utils-shadow/package.json
+++ b/modules/iotacss-utils-shadow/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "iotacss-utils-shadow",
+    "version": "1.0.0",
+    "description": "Box Shadow utility for iotaCSS",
+    "main": "_utilities.shdadow.scss",
+    "repository": "https://github.com/iotacss/iotacss/tree/master/modules/iotacss-utils-shdadow",
+    "license": "Apache-2.0",
+    "keywords": [
+        "iotacss",
+        "css",
+        "sass",
+        "bem",
+        "oocss"
+    ],
+    "author": "Dimitris Psaropoulos <info@harby.me>"
+}

--- a/utilities/_shadow.scss
+++ b/utilities/_shadow.scss
@@ -1,0 +1,1 @@
+@import '../modules/iotacss-utils-shadow/utilities.shadow';


### PR DESCRIPTION
# Adding box shadow module

I have found myself "needing" box shadow utility classes creating them in my own stylesheet. Having them as an Iotacss module would make the local style files cleaner and would also put the utilities in the same place.